### PR TITLE
Remove renaming of 'name' column to 'Entity' from ranking results

### DIFF
--- a/add_names.py
+++ b/add_names.py
@@ -49,7 +49,7 @@ def write_output(names, analysis, fin, fout, community_details_out):
 
     result = result.merge(names, on="id", how='inner')
     del result['id']
-    result.rename(columns={'name': 'Entity'}, inplace=True)
+    # result.rename(columns={'name': 'Entity'}, inplace=True)
 
     cols = result.columns.tolist()
 

--- a/merge_results.py
+++ b/merge_results.py
@@ -12,9 +12,10 @@ print("Community Detection\t3\tCombining Results with Ranking Scores")
 # read both ranking & community detection results
 ranking_df = pd.read_csv(config["final_ranking_out"], sep='\t')
 community_df = pd.read_csv(config["final_communities_out"], sep='\t')
+select_field = config["select_field"]
 
 # join on Entity column
-result = ranking_df.merge(community_df, on="Entity", how='inner')
+result = ranking_df.merge(community_df, on=select_field, how='inner')
 
 result.sort_values(by=["Community", "Ranking Score"], ascending=[True, False], inplace=True)
 


### PR DESCRIPTION
- Remove renaming of 'name' column to 'Entity' and maintain the select
field column's name
- Modify merge of 'community detection' and 'ranking' results to merge
on the selected field column name